### PR TITLE
I've centered the site description text on the homepage.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -77,7 +77,7 @@
         <div style="text-align: center; margin-bottom: 2em;">
             <img src="{{ '/assets/images/default-ogp.png' | relative_url }}" alt="{{ site.title }}" style="max-width: 800px; width: 100%; height: auto;">
         </div>
-        <p>このサイトは、Google Gemini を使用した DeepResearch の結果を個人的にまとめたものです。</p>
+        <p style="text-align: center;">このサイトは、Google Gemini を使用した DeepResearch の結果を個人的にまとめたものです。</p>
 
         <div class="category-filter">
             <button class="category-btn active" data-category="all" title="すべて表示">📚</button>


### PR DESCRIPTION
The text "このサイトは、Google Gemini を使用した DeepResearch の結果を個人的にまとめたものです。" is now centered on the homepage. I achieved this by adding an inline style to the corresponding p tag.