### PR TITLE
feat: パッケージ管理をnpmからpnpmに移行

### DIFF
--- a/.github/workflows/pr-deploy-screenshot.yml
+++ b/.github/workflows/pr-deploy-screenshot.yml
@@ -14,13 +14,11 @@ jobs:
     steps:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Setup bundle cache

--- a/.github/workflows/pr-deploy-screenshot.yml
+++ b/.github/workflows/pr-deploy-screenshot.yml
@@ -12,13 +12,16 @@ jobs:
   build-and-screenshot:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup node_modules cache
-        uses: actions/cache@v5
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
         with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          version: 11
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
 
       - name: Setup bundle cache
         uses: actions/cache@v5
@@ -32,21 +35,21 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package.json') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
 
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y ruby-dev nodejs npm libvips libnss3 libgtk-3-0 libgbm-dev \
+          sudo apt-get install -y ruby-dev libvips libnss3 libgtk-3-0 libgbm-dev \
             fonts-noto-cjk fonts-noto-cjk-extra fontconfig libfontconfig1 libfreetype6 \
             libxss1 libxshmfence-dev libatk-bridge2.0-0
           # Ubuntu 24.04以降のlibasound2はlibasound2t64にリネームされているため、存在すればそちらをインストール
           if apt-cache show libasound2t64 > /dev/null 2>&1; then sudo apt-get install -y libasound2t64; fi
           # フォントキャッシュの更新
           fc-cache -fv
-          npm -v
+          pnpm -v
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -61,7 +64,7 @@ jobs:
           gem install bundler
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
-          npm install
+          pnpm install --frozen-lockfile
 
       - name: Build site (Jekyll)
         run: |
@@ -88,7 +91,7 @@ jobs:
         run: |
           # キャッシュがない場合のみインストール
           if [ ! -d ~/.cache/ms-playwright ]; then
-            npx playwright install chromium
+            pnpm exec playwright install chromium
           fi
 
       - name: Capture screenshots

--- a/.github/workflows/pr-deploy-screenshot.yml
+++ b/.github/workflows/pr-deploy-screenshot.yml
@@ -12,8 +12,8 @@ jobs:
   build-and-screenshot:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-deploy-screenshot.yml
+++ b/.github/workflows/pr-deploy-screenshot.yml
@@ -12,6 +12,9 @@ jobs:
   build-and-screenshot:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Install pnpm
         uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
@@ -48,9 +51,6 @@ jobs:
           # フォントキャッシュの更新
           fc-cache -fv
           pnpm -v
-
-      - name: Checkout code
-        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ Thumbs.db
 # Jekyll関連の一時ファイル
 .jekyll-metadata
 .jekyll-cache/
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "share-deepresearch-screenshot",
   "version": "1.0.0",
+  "packageManager": "pnpm@11.1.1",
   "description": "Screenshot automation for PR deploys using Playwright.",
   "main": "scripts/screenshot.js",
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,43 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      playwright:
+        specifier: ^1.44.0
+        version: 1.60.0
+
+packages:
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2


### PR DESCRIPTION
## 概要
パッケージ管理ツールを npm から pnpm に移行しました。

## 変更内容
- `pnpm-lock.yaml` の生成
- `package.json` に `packageManager: pnpm` を指定
- `.github/workflows/pr-deploy-screenshot.yml` を pnpm 対応に更新
- `.gitignore` に `node_modules` を追加
