### PR TITLE
🔒 Fix potential command injection via github.head_ref in workflow

### DIFF
--- a/.github/workflows/auto-update-files.yml
+++ b/.github/workflows/auto-update-files.yml
@@ -71,6 +71,10 @@ jobs:
           done
 
       - name: Commit changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # Configure git user
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
@@ -78,10 +82,10 @@ jobs:
 
           # Determine the branch name to push to
           BRANCH_TO_PUSH=""
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            BRANCH_TO_PUSH="${{ github.head_ref }}" # e.g., feature-branch
+          if [ "$EVENT_NAME" == "pull_request" ]; then
+            BRANCH_TO_PUSH="$HEAD_REF" # e.g., feature-branch
           else # This covers push events
-            BRANCH_TO_PUSH="${{ github.ref_name }}" # e.g., main
+            BRANCH_TO_PUSH="$REF_NAME" # e.g., main
           fi
 
           echo "Attempting to commit and push to branch: $BRANCH_TO_PUSH"


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was a potential command injection in the `.github/workflows/auto-update-files.yml` workflow file.

⚠️ **Risk:** The vulnerability existed because `${{ github.head_ref }}` and other GitHub context variables were directly interpolated into a `run` step bash script. An attacker could potentially create a malicious branch name containing shell commands (e.g., `feature-branch"; echo "pwned"`). If triggered, the injected shell commands would run within the context of the GitHub Actions runner, potentially leading to unauthorized access, code execution, or access to secrets.

🛡️ **Solution:** The fix replaces the direct interpolation of context variables with environment variables via an `env` block. The bash script was updated to use standard environment variable references (e.g. `$EVENT_NAME`, `$HEAD_REF`, `$REF_NAME`), ensuring that the shell evaluates the values securely as literal strings, mitigating any command injection risk.

---
*PR created automatically by Jules for task [9041270997860786510](https://jules.google.com/task/9041270997860786510) started by @aegisfleet*